### PR TITLE
Yeet CASC (WIP)

### DIFF
--- a/src/client/component/database.cpp
+++ b/src/client/component/database.cpp
@@ -39,7 +39,7 @@ namespace database
 				nullptr
 			};
 
-			int default_value = utils::io::directory_exists("Data/data") ? 0 : 1;
+			int default_value = (utils::io::directory_exists("Data/data") && utils::io::directory_exists("Data/config") && utils::io::directory_exists("Data/indices")) ? 0 : 1;
 			db_filesysImpl = dvars::register_enum("db_filesysImpl", values, default_value, game::DVAR_FLAG_READ);
 
 			if (default_value == 1)

--- a/src/client/component/database.cpp
+++ b/src/client/component/database.cpp
@@ -1,0 +1,58 @@
+#include <std_include.hpp>
+#include "loader/component_loader.hpp"
+
+#include "game/dvars.hpp"
+#include "game/game.hpp"
+
+#include <utils/flags.hpp>
+#include <utils/hook.hpp>
+
+namespace database
+{
+	namespace
+	{
+		game::dvar_t* db_filesysImpl = nullptr;
+
+		utils::hook::detour sub_140272EC0_hook;
+
+		game::DB_FileSysInterface* sub_140272EC0_stub()
+		{
+			switch (db_filesysImpl->current.integer)
+			{
+			case 0:
+				return reinterpret_cast<game::DB_FileSysInterface*>(0x140BE82F8); // ptr to vtable of BnetTACTVFSManager (implements DB_FileSysInterface)
+			case 1:
+				return reinterpret_cast<game::DB_FileSysInterface*>(0x140BEFDC0); // ptr to vtable of DiskFS (implements DB_FileSysInterface)
+			default:
+				return nullptr; // this should not happen
+			}
+		}
+
+		
+	}
+
+	class component final : public component_interface
+	{
+	public:
+		void post_unpack() override
+		{
+			static const char* values[] = {
+				"BnetTACTVFSManager", // (load files from CASC)
+				"DiskFS", // (load files from disk)
+				nullptr
+			};
+
+			int default_value = utils::flags::has_flag("disk") ? 1 : 0;
+			db_filesysImpl = dvars::register_enum("db_filesysImpl", values, default_value, game::DVAR_FLAG_READ);
+
+			if (default_value == 1)
+			{
+				utils::hook::nop(0x1405A4868, 22); // TACT related stuff that's pointless if we're using DiskFS
+			}
+			
+			sub_140272EC0_hook.create(0x140272EC0, sub_140272EC0_stub);
+		}
+	};
+}
+
+REGISTER_COMPONENT(database::component)

--- a/src/client/game/dvars.cpp
+++ b/src/client/game/dvars.cpp
@@ -2223,7 +2223,7 @@ namespace dvars
     };
 
 	game::dvar_t* register_int(const std::string& name, int value, int min, int max, 
-		game::DvarFlags flags)
+		unsigned int flags)
 	{
 		dvar_list.insert(name);
 		const auto hash = game::generateHashValue(name.data());
@@ -2231,14 +2231,14 @@ namespace dvars
 	}
 
 	game::dvar_t* register_bool(const std::string& name, bool value, 
-		game::DvarFlags flags)
+		unsigned int flags)
 	{
 		dvar_list.insert(name);
 		const auto hash = game::generateHashValue(name.data());
 		return game::Dvar_RegisterBool(hash, "", value, flags);
 	}
 
-    game::dvar_t* register_enum(const std::string& name, const char** valueList, int defaultIndex, game::DvarFlags flags)
+    game::dvar_t* register_enum(const std::string& name, const char** valueList, int defaultIndex, unsigned int flags)
     {
         dvar_list.insert(name);
         const auto hash = game::generateHashValue(name.data());
@@ -2246,7 +2246,7 @@ namespace dvars
     }
 
 	game::dvar_t* register_float(const std::string& name, float value, float min, 
-		float max, game::DvarFlags flags)
+		float max, unsigned int flags)
 	{
 		dvar_list.insert(name);
 		const auto hash = game::generateHashValue(name.data());
@@ -2254,7 +2254,7 @@ namespace dvars
 	}
 
 	game::dvar_t* register_vec4(const std::string& name, float x, float y, float z, 
-		float w, float min, float max, game::DvarFlags flags)
+		float w, float min, float max, unsigned int flags)
 	{
 		dvar_list.insert(name);
 		const auto hash = game::generateHashValue(name.data());

--- a/src/client/game/dvars.cpp
+++ b/src/client/game/dvars.cpp
@@ -2238,6 +2238,13 @@ namespace dvars
 		return game::Dvar_RegisterBool(hash, "", value, flags);
 	}
 
+    game::dvar_t* register_enum(const std::string& name, const char** valueList, int defaultIndex, game::DvarFlags flags)
+    {
+        dvar_list.insert(name);
+        const auto hash = game::generateHashValue(name.data());
+        return game::Dvar_RegisterEnum(hash, "", valueList, defaultIndex, flags);
+    }
+
 	game::dvar_t* register_float(const std::string& name, float value, float min, 
 		float max, game::DvarFlags flags)
 	{

--- a/src/client/game/dvars.hpp
+++ b/src/client/game/dvars.hpp
@@ -29,9 +29,9 @@ namespace dvars
 	std::string dvar_get_vector_domain(const int components, const game::dvar_limits& domain);
 	std::string dvar_get_domain(const game::dvar_type type, const game::dvar_limits& domain);
 
-	game::dvar_t* register_int(const std::string& name, int value, int min, int max, game::DvarFlags flags);
-	game::dvar_t* register_bool(const std::string& name, bool value, game::DvarFlags flags);
-	game::dvar_t* register_enum(const std::string& name, const char** valueList, int defaultIndex, game::DvarFlags flags);
-	game::dvar_t* register_float(const std::string& name, float value, float min, float max, game::DvarFlags flags);
-	game::dvar_t* register_vec4(const std::string& name, float x, float y, float z, float w, float min, float max, game::DvarFlags flags);
+	game::dvar_t* register_int(const std::string& name, int value, int min, int max, unsigned int flags);
+	game::dvar_t* register_bool(const std::string& name, bool value, unsigned int flags);
+	game::dvar_t* register_enum(const std::string& name, const char** valueList, int defaultIndex, unsigned int flags);
+	game::dvar_t* register_float(const std::string& name, float value, float min, float max, unsigned int flags);
+	game::dvar_t* register_vec4(const std::string& name, float x, float y, float z, float w, float min, float max, unsigned int flags);
 }

--- a/src/client/game/dvars.hpp
+++ b/src/client/game/dvars.hpp
@@ -31,6 +31,7 @@ namespace dvars
 
 	game::dvar_t* register_int(const std::string& name, int value, int min, int max, game::DvarFlags flags);
 	game::dvar_t* register_bool(const std::string& name, bool value, game::DvarFlags flags);
+	game::dvar_t* register_enum(const std::string& name, const char** valueList, int defaultIndex, game::DvarFlags flags);
 	game::dvar_t* register_float(const std::string& name, float value, float min, float max, game::DvarFlags flags);
 	game::dvar_t* register_vec4(const std::string& name, float x, float y, float z, float w, float min, float max, game::DvarFlags flags);
 }

--- a/src/client/game/structs.hpp
+++ b/src/client/game/structs.hpp
@@ -1102,12 +1102,12 @@ namespace game
 
 	struct DB_FileSysInterface;
 
-	// this is a best guess, interface doesn't match up exactly w/other games (IW8)
+	// this is a best guess, interface doesn't match up exactly w/other games (IW8, T9)
 	struct DB_FileSysInterface_vtbl
 	{
 		DB_IFileSysFile* (__fastcall* OpenFile)(DB_FileSysInterface* _this, Sys_Folder folder, const char* filename);
-		FileSysResult (__fastcall* StartRead)(DB_FileSysInterface* _this, DB_IFileSysFile* handle, unsigned __int64 /* idk */, unsigned __int64 offset, unsigned __int64 size);
-		FileSysResult (__fastcall* NumberOfBytesRead)(DB_FileSysInterface* _this, DB_IFileSysFile* handle, unsigned __int64* bytesRead);
+		FileSysResult (__fastcall* Read)(DB_FileSysInterface* _this, DB_IFileSysFile* handle, unsigned __int64 offset, unsigned __int64 size, void* dest);
+		FileSysResult (__fastcall* Tell)(DB_FileSysInterface* _this, DB_IFileSysFile* handle, unsigned __int64* bytesRead);
 		__int64 (__fastcall* Size)(DB_FileSysInterface* _this, DB_IFileSysFile* handle);
 		void (__fastcall* Close)(DB_FileSysInterface* _this, DB_IFileSysFile* handle);
 		bool (__fastcall* Exists)(DB_FileSysInterface* _this, Sys_Folder folder, const char* filename);
@@ -1116,6 +1116,13 @@ namespace game
 	struct DB_FileSysInterface
 	{
 		DB_FileSysInterface_vtbl* vftbl;
+	};
+
+	__declspec(align(8)) struct DiskFile
+	{
+		DWORD status;
+		HANDLE handle;
+		_OVERLAPPED overlapped;
 	};
 
 	namespace hks

--- a/src/client/game/structs.hpp
+++ b/src/client/game/structs.hpp
@@ -1079,6 +1079,45 @@ namespace game
 		bool startsolid; // Confirmed in PM_JitterPoint
 	};
 
+	enum Sys_Folder : std::int32_t
+	{
+		SF_ZONE = 0x0,
+		SF_ZONE_LOC = 0x1,
+		SF_VIDEO = 0x2,
+		SF_VIDEO_LOC = 0x3,
+		SF_PAKFILE = 0x4,
+		SF_PAKFILE_LOC = 0x5,
+		SF_ZONE_REGION = 0x6,
+		SF_COUNT = 0x7,
+	};
+
+	enum FileSysResult : std::int32_t
+	{
+		FILESYSRESULT_SUCCESS = 0x0,
+		FILESYSRESULT_EOF = 0x1,
+		FILESYSRESULT_ERROR = 0x2,
+	};
+
+	struct DB_IFileSysFile;
+
+	struct DB_FileSysInterface;
+
+	// this is a best guess, interface doesn't match up exactly w/other games (IW8)
+	struct DB_FileSysInterface_vtbl
+	{
+		DB_IFileSysFile* (__fastcall* OpenFile)(DB_FileSysInterface* _this, Sys_Folder folder, const char* filename);
+		FileSysResult (__fastcall* StartRead)(DB_FileSysInterface* _this, DB_IFileSysFile* handle, unsigned __int64 /* idk */, unsigned __int64 offset, unsigned __int64 size);
+		FileSysResult (__fastcall* NumberOfBytesRead)(DB_FileSysInterface* _this, DB_IFileSysFile* handle, unsigned __int64* bytesRead);
+		__int64 (__fastcall* Size)(DB_FileSysInterface* _this, DB_IFileSysFile* handle);
+		void (__fastcall* Close)(DB_FileSysInterface* _this, DB_IFileSysFile* handle);
+		bool (__fastcall* Exists)(DB_FileSysInterface* _this, Sys_Folder folder, const char* filename);
+	};
+
+	struct DB_FileSysInterface
+	{
+		DB_FileSysInterface_vtbl* vftbl;
+	};
+
 	namespace hks
 	{
 		struct GenericChunkHeader

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -37,6 +37,7 @@ namespace game
 	WEAK symbol<const char*(const XAsset* asset)> DB_GetXAssetName{0x1403E4090};
 	WEAK symbol<void(XZoneInfo* zoneInfo, unsigned int zoneCount, DBSyncMode syncMode)> DB_LoadXAssets{0x140414FF0};
 	WEAK symbol<XAssetHeader(XAssetType type, const char* name, int allowCreateDefault)> DB_FindXAssetHeader{0x140412F60};
+	WEAK symbol<DB_FileSysInterface*()> DB_FSInitialize{0x140272EC0};
 	WEAK symbol<int(const RawFile* rawfile)> DB_GetRawFileLen{0x140413D80};
 	WEAK symbol<int(const RawFile* rawfile, char* buf, int size)> DB_GetRawBuffer{0x140413C40};
 
@@ -127,6 +128,7 @@ namespace game
 	WEAK symbol<void()> R_WaitWorkerCmds{0x140794330};
 	WEAK symbol<void(const void* obj, void* pose, unsigned int entnum, unsigned int renderFxFlags, float* lightingOrigin, 
 		float materialTime, __int64 a7, __int64 a8)> R_AddDObjToScene{0x140775C40};
+	WEAK symbol<HANDLE(unsigned __int64* outUserData, void* dest, unsigned __int64 bytes)> R_Cinematic_SysIO_BinkRead{0x1407191B0};
 
 	WEAK symbol<ScreenPlacement*()> ScrPlace_GetViewPlacement{0x1403E16A0};
 	WEAK symbol<ScreenPlacement*()> ScrPlace_GetView{0x1403E1660};
@@ -163,6 +165,7 @@ namespace game
 	WEAK symbol<HWND> hWnd{0x14CCF81C0};
 
 	WEAK symbol<const char*> g_assetNames{0x140BEF280};
+
 	WEAK symbol<int> g_poolSize{0x140BF2E40};
 
 	WEAK symbol<gentity_s> g_entities{0x1452DDDA0};
@@ -190,6 +193,8 @@ namespace game
 	WEAK symbol<scrVarGlob_t> scr_VarGlob{0x14B617C00};
 	WEAK symbol<scrVmPub_t> scr_VmPub{0x14BA9EE40};
 	WEAK symbol<function_stack_t> scr_function_stack{0x14BAA93C0};
+
+	WEAK symbol<DB_FileSysInterface*> g_fileSystem{0x1420B27E8};
 
 	namespace hks
 	{

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -43,6 +43,7 @@ namespace game
 	WEAK symbol<dvar_t*(const char* name)> Dvar_FindVar{0x140618F90};
 	WEAK symbol<void(char* buffer, int index)> Dvar_GetCombinedString{0x1405A75D0};
 	WEAK symbol<dvar_t*(int hash, const char* name, bool value, unsigned int flags)> Dvar_RegisterBool{0x140617BB0};
+	WEAK symbol<dvar_t*(int hash, const char* name, const char** valueList, int defaultIndex, unsigned int flags)> Dvar_RegisterEnum{0x140617E90};
 	WEAK symbol<dvar_t*(int hash, const char* name, int value, int min, int max, unsigned int flags)> Dvar_RegisterInt{0x140618090};
 	WEAK symbol<dvar_t*(int hash, const char* dvarName, float value, float min, float max, unsigned int flags)>
 		Dvar_RegisterFloat{0x140617F80};


### PR DESCRIPTION
This is a work-in-progress effort to provide the ability to change the active implementation of `DB_FileSysInterface` to `DiskFS` instead of `BnetTACTVFSManager` (default). Using `DiskFS` as the active implementation allows for game files to be loaded directly from the filesystem, bypassing battle.net's CASC containers entirely.