### PR TITLE
Return correct working directory

### DIFF
--- a/src/client/component/filesystem.cpp
+++ b/src/client/component/filesystem.cpp
@@ -73,6 +73,12 @@ namespace filesystem
 
 			return true;
 		}
+
+		const char* sys_default_install_path_stub()
+		{
+			static auto current_path = std::filesystem::current_path().string();
+			return current_path.data();
+		}
 	}
 
 	std::string read_file(const std::string& path)
@@ -198,6 +204,7 @@ namespace filesystem
 		void post_unpack() override
 		{
 			utils::hook::call(0x14060B052, fs_startup_stub);
+			utils::hook::jump(0x140624050, sys_default_install_path_stub);
 		}
 	};
 }


### PR DESCRIPTION
What does this PR do?
- It allows the h2-mod binary to work outside of the game folder.

This was not possible before because if the binary was outside of the game folder sys_default_install_path would return the incorrect path (it would return dir where h2-mod exe is located instead of the actual working directory).
This is because that's how h2-mod loader works. if the exe was loaded as a library like s1x it would require different kinds of patches, but this is all for h2.
